### PR TITLE
Add supply chain security defaults

### DIFF
--- a/.github/workflows/label-merge-conflicts.yml
+++ b/.github/workflows/label-merge-conflicts.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - main
+  # TODO(supply-chain-security): Human review: this workflow uses pull_request_target; keep permissions minimal and do not check out or run untrusted PR code here.
   pull_request_target:
 
 

--- a/.github/workflows/sync.yaml
+++ b/.github/workflows/sync.yaml
@@ -1,6 +1,7 @@
 name: 'Upstream Sync'
 
 permissions:
+  # TODO(supply-chain-security): Human review: confirm this scheduled sync still requires contents: write and narrow if the sync action supports lower privileges.
   contents: write
 
 on:
@@ -12,6 +13,7 @@ on:
 jobs:
   sync_latest_from_upstream:
     permissions:
+        # TODO(supply-chain-security): Human review: confirm this job still requires contents: write for upstream sync.
         contents: write
     runs-on: ubuntu-latest
     name: Sync latest commits from upstream repo

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=3

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,6 @@ cache:
   directories:
     - "node_modules"
 
+install: npm ci
+
 script: npm run-script build


### PR DESCRIPTION
Adopts the recommended supply chain security defaults from The Hub: https://thehub.github.com/news/2026-05-20-supply-chain-security-stay-safe/

Changes are intentionally minimal and repo-appropriate. Items needing human review are noted as TODOs in the diff.
